### PR TITLE
Setting useNativeDriver->false for animation to work

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,7 +10,7 @@ import {
 } 
 from "./src/Firebase";
 import { AsyncStorage, NativeModules } from "react-native";
-import SettingScreen from "./src/Components/SettingsScreen";
+import SettingsScreen from "./src/Components/SettingsScreen";
 import ForgotPasswordPage from "./src/Components/ForgotPasswordPage";
 //import * as firebase from "firebase";
 

--- a/src/Components/LetsGetStarted.jsx
+++ b/src/Components/LetsGetStarted.jsx
@@ -24,7 +24,7 @@ export default LetsGetStarted = (props) => {
     let _start = () => {
         Animated.timing(fadeValue, {
             toValue: 1,
-            useNativeDriver: true,
+            useNativeDriver: false,
             duration: 1000
         }).start();
     };

--- a/src/Components/LogIn.jsx
+++ b/src/Components/LogIn.jsx
@@ -37,7 +37,7 @@ export default LogIn = props => {
     let _start = () => {
         Animated.timing(fadeValue, {
             toValue: 1,
-            useNativeDriver: true,
+            useNativeDriver: false,
             duration: 2000
         }).start();
     };

--- a/src/Components/LowerPanel.jsx
+++ b/src/Components/LowerPanel.jsx
@@ -45,7 +45,7 @@ export default LowerPanel = props => {
       Animated.timing(moveAnim, {
         toValue: destination,
         duration: 150,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     
   };
@@ -56,6 +56,7 @@ export default LowerPanel = props => {
       Animated.timing(moveAnim, {
         toValue: destination,
         duration: 0,
+        useNativeDriver: false,
       }).start();
   }
 


### PR DESCRIPTION
This setting solves a warning we were having on our ios simulator complaining about useNativeDriver being a required option. Also adding an 's' someone omitted when changing from Setting to Settings.