### PR TITLE
filter by services updated

### DIFF
--- a/src/Components/FindCare.jsx
+++ b/src/Components/FindCare.jsx
@@ -64,19 +64,14 @@ export default function FindCare(props) {
 
   let servicesArray = [
     'All',
-    'Education',
-    'Support & Counseling',
-    'Free Materials',
-    'Referrals',
-    'STD Tests',
-    'STD Treatment',
-    'Yearly Exam',
-    'Pregnancy Tests',
-    'Ultrasound',
-    'Immunization',
     'Abortions',
-    'Medical Care',
+    'Free Materials',
+    'Immunization',
     'Lab services',
+    'Medical Care',
+    'Pregnancy Tests',
+    'Referrals',
+    'Yearly Exam',
   ];
 
   let services = servicesArray.map((service) => ({


### PR DESCRIPTION
Service Filtering Changes #165 
Reduced the array of services passed to the filter feature used by the user to filter clinics by service. The removed services will still be displayed in the list of services the clinic offers at the botton of the clinic information. If the clinics do not provide those services anymore please remove that information from the DB.