### PR TITLE
Fixes issue #183. Tested on iPhone 8 Plus and Galaxy S8

### DIFF
--- a/src/Components/LogIn.jsx
+++ b/src/Components/LogIn.jsx
@@ -100,7 +100,7 @@ export default LogIn = (props) => {
         </TouchableHighlight>
         <View
               style={{
-                paddingTop: appStyles.win.height * 0.05,
+                paddingTop: appStyles.win.height * 0.075,
                 alignItems: 'center',
               }}>
               <SwipeUp


### PR DESCRIPTION
Increased the padding so the arrow appears lower than before. Could you test it on the device that was giving you problems Eduardo to verify? Thanks.