### PR TITLE
fixes immunization page error

### DIFF
--- a/src/Components/Immunization.jsx
+++ b/src/Components/Immunization.jsx
@@ -20,7 +20,7 @@ export default function Immunization(props) {
   const email = getUEmail();
 
   getImmunization = () => {
-    fetchImmunization(uid, setObjects, _isMounted);
+    fetchImmunization(uid, setObjects, isMounted);
   };
 
   removeImmunization = (id) => {


### PR DESCRIPTION
Fixed variable typo, which was causing the immunization page to crash. This is a change that has previously been made to the development branch, but not to expo42.