### PR TITLE
Fix Unreadable Date-Time Picker on IOS Dark Mode

### DIFF
--- a/src/Components/NewAppointment.jsx
+++ b/src/Components/NewAppointment.jsx
@@ -227,6 +227,7 @@ export default function NewAppointment(props) {
             onCancel={hideDatePicker}
             is24Hour
             headerTextIOS={translate('dateHeader')}
+            textColor = 'black'
           />
         </View>
         <View style={styles.seperator} />
@@ -242,6 +243,7 @@ export default function NewAppointment(props) {
             onCancel={hideTimePicker}
             is24Hour
             headerTextIOS={translate('timeHeader')}
+            textColor = 'black'
           />
         </View>
         <View style={styles.seperator} />

--- a/src/Components/NewImmunization.jsx
+++ b/src/Components/NewImmunization.jsx
@@ -169,6 +169,7 @@ export default function NewImmunization(props) {
           onCancel={hideDatePicker}
           is24Hour
           headerTextIOS="Pick a date"
+          textColor = 'black'
         />
       </View>
       <View style={styles.seperator} />


### PR DESCRIPTION
Repost of #369 , which fixes #368

To test this, you must be on iOS 13.0 or greater. You should switch your device's appearance to Dark Mode in your settings, and then open the application and see if you are able to see the date and time pickers on the application.

See issue #368 for more information.