### PR TITLE
Fixed Issue with immunizations not rendering

### DIFF
--- a/src/Components/Appointment.jsx
+++ b/src/Components/Appointment.jsx
@@ -13,12 +13,11 @@ import Plus from '../../assets/plus.png';
 import {deleteAppointment, fetchAppointment, getUid} from '../Firebase';
 
 export default function Appointment(props) {
-  const _isMounted = false;
   const [objects, setObjects] = useState([]);
   const uid = getUid();
 
   getAppointment = () => {
-    fetchAppointment(uid, setObjects, _isMounted);
+    fetchAppointment(uid, setObjects);
   };
 
   removeAppointment = (id, eventId) => {

--- a/src/Components/Immunization.jsx
+++ b/src/Components/Immunization.jsx
@@ -14,14 +14,9 @@ import {
 } from '../Firebase';
 
 export default function Immunization(props) {
-  const _isMounted = false;
   const [objects, setObjects] = useState([]);
   const uid = getUid();
   const email = getUEmail();
-
-  getImmunization = () => {
-    fetchImmunization(uid, setObjects, _isMounted);
-  };
 
   removeImmunization = (id) => {
     deleteImmunization(id, uid, objects, setObjects);
@@ -29,7 +24,7 @@ export default function Immunization(props) {
 
   useFocusEffect(
     React.useCallback(() => {
-      getImmunization();
+      fetchImmunization(uid, setObjects);
       return () => {
         setObjects([]);
       };

--- a/src/Components/ImmunizationSchedule.jsx
+++ b/src/Components/ImmunizationSchedule.jsx
@@ -13,17 +13,11 @@ import {fetchImmunization, getUid} from '../Firebase';
 import translate from './getLocalizedText';
 
 export default function ImmunizationSchedule(props) {
-  let _isMounted = false;
   const [objects, setObjects] = useState([]);
   const uid = getUid();
 
-  getImmunization = () => {
-    fetchImmunization(uid, setObjects, _isMounted);
-  };
-
   useEffect(() => {
-    getImmunization();
-    return () => (_isMounted = false);
+    fetchImmunization(uid, setObjects);
   }, []);
 
   const scheduleData = [

--- a/src/Components/ReferenceNames.jsx
+++ b/src/Components/ReferenceNames.jsx
@@ -7,12 +7,11 @@ import ReferenceInfo from './ReferenceInfo';
 import {deleteReference, fetchReference, getUid} from '../Firebase';
 
 function ReferenceNames(props) {
-  let _isMounted = false;
   const [references, setReferences] = useState([]);
   const uid = getUid();
 
   getReferences = () => {
-    fetchReference(uid, setReferences, _isMounted);
+    fetchReference(uid, setReferences);
   };
 
   removeReference = (id) => {

--- a/src/Firebase.js
+++ b/src/Firebase.js
@@ -312,8 +312,7 @@ export const deleteAppointment = async (
   console.log("Error: Couldn't get the User appointment Info");
 };
 
-export const fetchAppointment = async (uid, setObjects, _isMounted) => {
-  _isMounted = true;
+export const fetchAppointment = async (uid, setObjects) => {
   if (uid !== null) {
     await firebase
       .database()
@@ -324,13 +323,8 @@ export const fetchAppointment = async (uid, setObjects, _isMounted) => {
           let childData = childSnapshot.val();
           console.log(childKey);
           console.log(childData);
-          if (
-            childSnapshot.val() !== null ||
-            childSnapshot.val() !== 'undefined'
-          ) {
-            if (_isMounted) {
-              setObjects((prevArray) => [...prevArray, childSnapshot]);
-            }
+          if (childSnapshot.val() !== null || childSnapshot.val() !== 'undefined') {
+            setObjects((prevArray) => [...prevArray, childSnapshot]);
           }
         });
       });
@@ -347,8 +341,7 @@ export const addAppointment = async (uid, appointmentInfo) => {
     .catch((err) => console.log(err));
 };
 
-export const fetchImmunization = async (uid, setObjects, _isMounted) => {
-  _isMounted = true;
+export const fetchImmunization = async (uid, setObjects) => {
   if (uid !== null) {
     await firebase
       .database()
@@ -357,13 +350,8 @@ export const fetchImmunization = async (uid, setObjects, _isMounted) => {
         snapshot.forEach((childSnapshot) => {
           let childKey = childSnapshot.key;
           let childData = childSnapshot.val();
-          if (
-            childSnapshot.val() !== null ||
-            childSnapshot.val() !== 'undefined'
-          ) {
-            if (_isMounted) {
-              setObjects((prevArray) => [...prevArray, childSnapshot]);
-            }
+          if (childSnapshot.val() !== null || childSnapshot.val() !== 'undefined') {
+            setObjects((prevArray) => [...prevArray, childSnapshot]);
           }
         });
       })
@@ -400,8 +388,7 @@ export const addReference = async (uid, referenceInfo) => {
     .catch((err) => console.log(err));
 };
 
-export const fetchReference = async (uid, setReferences, _isMounted) => {
-  _isMounted = true;
+export const fetchReference = async (uid, setReferences) => {
   if (uid !== null) {
     await firebase
       .database()
@@ -412,13 +399,8 @@ export const fetchReference = async (uid, setReferences, _isMounted) => {
           let childData = childSnapshot.val();
           console.log(childKey);
           console.log(childData);
-          if (
-            childSnapshot.val() !== null ||
-            childSnapshot.val() !== 'undefined'
-          ) {
-            if (_isMounted) {
-              setReferences((prevArray) => [...prevArray, childSnapshot]);
-            }
+          if (childSnapshot.val() !== null || childSnapshot.val() !== 'undefined') {
+            setReferences((prevArray) => [...prevArray, childSnapshot]);
           }
         });
       })


### PR DESCRIPTION
fixes #439

It turns out the issue was simply caused by the fact that both the `Immunization` and `Immunization Schedule` pages were using functions with the same name (getImmunization) in order to call the `fetchImmunization` function. I removed these `getImmunization` functions since they were redundant, so the immunizations should always render correctly now.

Also removed `_isMounted` variables in different files because these variables are redundant as well.