### PR TITLE
fix off screen menu component

### DIFF
--- a/src/Components/AppStyles.js
+++ b/src/Components/AppStyles.js
@@ -43,7 +43,6 @@ export default {
     maxWidth: '100%',
     backgroundColor: 'white',
     flex: 1,
-    paddingLeft: 25,
   },
   learnAndResourceTabContentContainer: {
     alignItems: 'center',
@@ -502,7 +501,6 @@ export default {
     alignItems: 'center',
     elevation: 5,
     zIndex: 999,
-    marginRight: 25,
     marginVertical: 10,
   },
 


### PR DESCRIPTION
for issue #541 - from my understanding, someone tried to fix the off center plus symbol by adding hard coded padding in the view, which in turn made the menu component go off screen completely. so i removed that padding and removed the margin that was originally causing the problem with the plus component. 
all the menus looked centered on my samsung, please test on an iphone