### PR TITLE
Fixed #479

### DIFF
--- a/src/Components/NewAppointment.jsx
+++ b/src/Components/NewAppointment.jsx
@@ -16,7 +16,9 @@ import * as Calendar from 'expo-calendar';
 import * as Localization from 'expo-localization';
 import * as Permissions from 'expo-permissions';
 import * as Notifications from 'expo-notifications';
+import {Appearance} from 'react-native';
 import Constants from 'expo-constants';
+import {colors} from 'react-native-elements';
 import translate from './getLocalizedText';
 import appStyles from './AppStyles';
 import Button from './Button';
@@ -34,6 +36,7 @@ Notifications.setNotificationHandler({
 export default function NewAppointment(props) {
   const [expoPushToken, setExpoPushToken] = useState('');
   const [notification, setNotification] = useState(false);
+  const [mode, setMode] = useState();
   const notificationListener = useRef();
   const responseListener = useRef();
 
@@ -184,6 +187,13 @@ export default function NewAppointment(props) {
     // need to handle perms not being granted, since it cannot create an appointment without reminders
   };
 
+  function checkMode() {
+    // check if user's device/machine is in dark/light mode to choose a contrasting color
+    const matchResult = Appearance.getColorScheme();
+    if (matchResult == 'dark') return 'white';
+    return 'black';
+  }
+
   return (
     <Pressable style={appStyles.contentContainer} onPress={Keyboard.dismiss}>
       <KeyboardAvoidingView
@@ -220,6 +230,7 @@ export default function NewAppointment(props) {
           <TouchableOpacity onPress={showDatePicker}>
             <Text style={styles.textStyle}>{date}</Text>
           </TouchableOpacity>
+
           <DateTimePickerModal
             isVisible={isDatePickerVisible}
             mode="date"
@@ -227,7 +238,7 @@ export default function NewAppointment(props) {
             onCancel={hideDatePicker}
             is24Hour
             headerTextIOS={translate('dateHeader')}
-            textColor="black"
+            textColor={checkMode()}
           />
         </View>
         <View style={styles.seperator} />
@@ -243,7 +254,7 @@ export default function NewAppointment(props) {
             onCancel={hideTimePicker}
             is24Hour
             headerTextIOS={translate('timeHeader')}
-            textColor="black"
+            textColor={checkMode()}
           />
         </View>
         <View style={styles.seperator} />


### PR DESCRIPTION
Before: 


How the date selector originally looked. Dark text on a dark background if the user's device has dark-mode turned on.
![image](https://user-images.githubusercontent.com/90061079/224526120-e2b20663-a1df-42ec-a89a-7251195e07f6.png)



After: 


Time selector change (device dark mode on)
![simulator_screenshot_7CE9D4C7-A835-4B64-8162-AC59FC83175F](https://user-images.githubusercontent.com/90061079/224526205-a745fe56-f8ec-4a55-9b2a-bd2aead1d705.png)


Time selector change (device dark mode off)
![simulator_screenshot_AD1D7D32-5809-44C5-B4DA-BCEAEDF798B1](https://user-images.githubusercontent.com/90061079/224526215-f8afdad0-8dc8-43f7-b6dc-4c20f87b3314.png)


Date selector change (device dark mode on)
![image](https://user-images.githubusercontent.com/90061079/224526241-3671927f-9c42-4085-afb9-1a5ff5294947.png)


Date selector change (device dark mode off)
![image](https://user-images.githubusercontent.com/90061079/224526244-dc5b2f5e-8e16-4c99-af56-7956259d5e64.png)

Summary: Fixed issue #479. The date selector text color on the appointments tab now switches to a white color if the user's device is in dark mode. If the user is not in dark mode, the text will appear black. (Note: The _**background**_ of the date selector changing color was already a previously made feature if dark-mode is toggled on/off). I took the liberty of making the same changes to the time selector, as seen in the pictures. As the time selector had the same problem originally. 
