### PR TITLE
Fixed the Feeding page spacing in Foods to Avoid and Important Notes

### DIFF
--- a/src/Components/AppStyles.js
+++ b/src/Components/AppStyles.js
@@ -261,7 +261,7 @@ export default {
   FeedingNotes: {
     Touchable: {
       margin: 5,
-      padding: 10,
+      padding: 20,
       backgroundColor: 'white',
       ...shadow,
       width: win.width * 0.95,
@@ -277,7 +277,7 @@ export default {
     Text: {
       color: darkGreyColor,
       fontSize: regularFontSize,
-      textAlign: 'justify',
+      letterSpacing: .25,
     },
   },
   ImageOnRightSelectionButton: {


### PR DESCRIPTION
Adjusted the letter spacing for 'Foods to Avoid' and 'Important Notes' in the Feeding page.

Expected result:
![image](https://github.com/edumorlom/nuMom/assets/44759869/b512bcf3-3771-470c-b985-9c482b03d498)
![image](https://github.com/edumorlom/nuMom/assets/44759869/35c3ee0d-95e4-46c0-ad51-3ef699df4ec9)
