### PR TITLE
6243034/issue592 Add weak password alert and checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,22 +75,8 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-standard": "^4.0.2",
-    "husky": "^4.3.0",
     "lint-staged": "^10.5.0",
     "prettier": "^2.8.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.+(js|jsx|json|css|md)": [
-      "npm run format"
-    ],
-    "*.+(js|jsx)": [
-      "npm run esfix"
-    ]
   },
   "private": true
 }

--- a/src/Components/SignUpPassword.jsx
+++ b/src/Components/SignUpPassword.jsx
@@ -30,6 +30,8 @@ export default SignUpPassword = (props) => {
   const [showRepeat, setShowRepeat] = React.useState(false);
   const [visible, setVisible] = React.useState(true);
   const [visibleRepeat, setVisibleRepeat] = React.useState(true);
+  const special_chars = ['!','#','$','*','%'];
+  let containsSpecialChar = false;
 
   useEffect(() => {
     AsyncStorage.getItem('pass').then((value) => {
@@ -41,12 +43,20 @@ export default SignUpPassword = (props) => {
   }, []);
 
   let onPress = () => {
+    for (let i = 0; i < password.length; i++) {
+      if (special_chars.includes(password[i])){
+        containsSpecialChar = true;
+        break;
+      }
+    }
     if (password !== repeat) {
       alert(translate('passwordMismatch'));
     } else if (!password || !repeat) {
       alert(translate('fillOutAllFields'));
     } else if (password.length < 6) {
       alert(translate('passwordTooShort'));
+    } else if (!containsSpecialChar){
+      alert(translate('passwordWeak'));
     } else {
       // props.setUserInfo({password});
       // AsyncStorage.setItem('pass', password);

--- a/src/en_US.json
+++ b/src/en_US.json
@@ -25,7 +25,7 @@
   "repeatPasswordInput": "Repeat Password",
   "passwordMismatch": "Your passwords don't match!",
   "passwordTooShort": "Your password must have at least 6 characters!",
-  "passwordWeak": "Your password is too weak",
+  "passwordWeak": "Your password is too weak. Add a special character (!,#,$,*,%)",
   "createPassword": "Create Password",
   "areYouPregnant": "Are You Pregnant?",
   "doYouHaveInfants": "Do You Have Any Infants?",

--- a/src/es_ES.json
+++ b/src/es_ES.json
@@ -25,7 +25,7 @@
   "repeatPasswordInput": "Repita la contraseña",
   "passwordMismatch": "¡Las contraseñas no son iguales!",
   "passwordTooShort": "¡Su contraseña debe tener al menos 6 carácteres!",
-  "passwordWeak": "Your password is too weak",
+  "passwordWeak": "Su contraseña es débil. Agregue un carácter especial (!,#,$,*,%)",
   "createPassword": "Cree su Contraseña",
   "areYouPregnant": "¿Está embarazada?",
   "doYouHaveInfants": "¿Tiene hijos?",

--- a/src/ht_HT.json
+++ b/src/ht_HT.json
@@ -25,6 +25,7 @@
   "repeatPasswordInput": "Repete kle sekirite",
   "passwordMismatch": "Kle sekirite sa yo pa mache!",
   "passwordTooShort": "Kle sekirite bezwen plis pase 6 karaktè!",
+  "passwordWeak": "test",
   "createPassword": "Kreye kle sekirite",
   "areYouPregnant": "Ou ansent?",
   "doYouHaveInfants": "Ou genyen timoun?",

--- a/src/ht_HT.json
+++ b/src/ht_HT.json
@@ -25,7 +25,7 @@
   "repeatPasswordInput": "Repete kle sekirite",
   "passwordMismatch": "Kle sekirite sa yo pa mache!",
   "passwordTooShort": "Kle sekirite bezwen plis pase 6 karaktè!",
-  "passwordWeak": "test",
+  "passwordWeak": "Modpas ou a twò fèb. Ajoute yon karaktè espesyal (!,#,$,*,%)",
   "createPassword": "Kreye kle sekirite",
   "areYouPregnant": "Ou ansent?",
   "doYouHaveInfants": "Ou genyen timoun?",


### PR DESCRIPTION
Issue #592 has a screenshot that shows an alert "Your passwords don't match!". The creator of the issue states that the password matches but is an example of a weak password. They want the alert to change to a warning that the password is too weak. 

When I tried to test this issue, there was no need to change anything. However, a weak password checker was added and the alert will pop up if necessary. Translations are included as well.

This shows that the password is weak.
![IMG_0174](https://github.com/edumorlom/nuMom/assets/95481049/026b75f7-4422-423d-9c6c-0cdc0c65b573)

The following two images will show that the password passes the criteria.
![IMG_0175](https://github.com/edumorlom/nuMom/assets/95481049/5bcb455e-9dd0-4603-84b2-f321dc8d172d)
![IMG_0176](https://github.com/edumorlom/nuMom/assets/95481049/a6d33e32-6f73-48c3-8277-a3cb47b6ddbb)



