### PR TITLE
Fixed regex expression to check for valid date.

### DIFF
--- a/src/Components/SettingsScreen.jsx
+++ b/src/Components/SettingsScreen.jsx
@@ -199,12 +199,12 @@ const SettingsScreen = (props) => {
   }
 
   function validateDob(dob) {
-    const dobRegex = /^([0-9]{2})\/([0-9]{2})\/([0-9]{4})$/;
+    const dobRegex = /^(0[1-9]|1[0-2])\/(0[1-9]|1\d|2\d|3[01])\/(19|20)\d{2}$/;
     return dob.match(dobRegex) !== null;
   }
 
   function validateBaby(babyDob, infant) {
-    const dobBabyRegex = /^([0-9]{2})\/([0-9]{2})\/([0-9]{4})$/;
+    const dobBabyRegex = /^(0[1-9]|1[0-2])\/(0[1-9]|1\d|2\d|3[01])\/(19|20)\d{2}$/;
     if (infant) {
       return babyDob.match(dobBabyRegex) !== null;
     }


### PR DESCRIPTION
Fixed the regex expression in the SettingsScreen.jsx so that it checks for a valid date for both the user and the infant.

![image](https://github.com/edumorlom/nuMom/assets/105022916/a219e1bf-ef61-4432-9285-92943d1e8620)
