### PR TITLE
Issue706: Fixed the margins of the settings button

### DIFF
--- a/src/Components/LowerPanelSelection.jsx
+++ b/src/Components/LowerPanelSelection.jsx
@@ -43,6 +43,8 @@ export default function LowerPanelSelection(props) {
           <MaterialIcons
             name="settings"
             size={45}
+            marginLeft={26}
+            marginBottom={3}
             color="gray"
             style={styles.userSettingStyle}
             onPress={() => navigation.navigate('SettingsScreen')}


### PR DESCRIPTION
Fixed the margins of the setttings button on the homepage to center it.

![image](https://github.com/edumorlom/nuMom/assets/105022916/7a255fae-f749-4b84-8b26-c02fab8216f2)
